### PR TITLE
updated run-dev to allow easier (non-hardcoded) changes for container prefixes

### DIFF
--- a/run-dev
+++ b/run-dev
@@ -2,8 +2,9 @@
 set -e
 
 SCRIPT_DIR=$(dirname $(readlink -f "${BASH_SOURCE[0]}"))
-IMAGE=dev/srb-build
-CONTAINER_NAME=srb-dev
+PREFIX=${PREFIX:-srb}
+IMAGE=dev/${PREFIX}-build
+CONTAINER_NAME=${PREFIX}-dev
 
 if docker ps -a | grep "${CONTAINER_NAME}" > /dev/null
 then


### PR DESCRIPTION
Shouldn't change how you use the script (defaults to "srb"), but makes it easier to update without digging into the script.